### PR TITLE
Implemented global switch default_fetch_blocks

### DIFF
--- a/config_spec.toml
+++ b/config_spec.toml
@@ -54,7 +54,7 @@ doc = "The port of the real bitcoind."
 
 [[param]]
 name = "user"
-type = "std::collections::HashMap<String, btc_rpc_proxy::User>"
+type = "std::collections::HashMap<String, btc_rpc_proxy::users::input::User>"
 merge_fn = "std::iter::Extend::extend"
 default = "Default::default()"
 argument = false
@@ -88,3 +88,7 @@ name = "tor_only"
 type = "bool"
 default = "false"
 doc = "Use tor for non-.onion peer connections"
+
+[[switch]]
+name = "default_fetch_blocks"
+doc = "Fetch blocks from peers for all users that do NOT specify fetch_blocks = false"

--- a/src/create_state.rs
+++ b/src/create_state.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Error;
-use btc_rpc_proxy::{AuthSource, Peers, RpcClient, State, TorState, Users};
+use btc_rpc_proxy::{AuthSource, Peers, RpcClient, State, TorState};
 use slog::Drain;
 use tokio::sync::RwLock;
 
@@ -45,7 +45,7 @@ pub fn create_state() -> Result<State, Error> {
         bind: (config.bind_address, config.bind_port).into(),
         rpc_client,
         tor,
-        users: Users(config.user),
+        users: btc_rpc_proxy::users::input::map_default(config.user, config.default_fetch_blocks),
         logger,
         peer_timeout: Duration::from_secs(config.peer_timeout),
         peers: RwLock::new(Arc::new(Peers::new())),


### PR DESCRIPTION
This change allows the users to globally enable `fetch_blocks` unless
specific user config says otherwise. This effectively turns it from
whitelist to blacklist. While it's a good practice to stay away from
blacklists, I believe it can be justified in this case as the call is
mostly harmless.

CC @dr-bonez 

I did not yet have the time to do full test (actually setting it in the config), I will do it a bit later. The change is straightforward, simple, type safe, and it contains basic unit tests (actually exhaustively checking all options since it seemed simple enough) so it shouldn't be considered noise. :)