### PR TITLE
Improvements to logging and error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ dependencies = [
  "slog-async",
  "slog-term",
  "socks",
+ "thiserror",
  "tokio",
 ]
 
@@ -1115,9 +1116,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "slog"
-version = "2.5.2"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc9c640a4adbfbcc11ffb95efe5aa7af7309e002adab54b185507dbf2377b99"
+checksum = "8347046d4ebd943127157b94d63abb990fcf729dc4e9978927fdf4ac3c998d06"
 
 [[package]]
 name = "slog-async"
@@ -1205,6 +1206,26 @@ checksum = "c0863a3345e70f61d613eab32ee046ccd1bcc5f9105fe402c61fcd0c13eeb8b5"
 dependencies = [
  "dirs",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 spec = "config_spec.toml"
 
 [features]
+default = ["debug_logs"]
 old_rust = []
 debug_logs = ["slog/max_level_debug"]
 
@@ -42,11 +43,12 @@ linear-map = { version = "1.2.0", features = ["serde_impl"] }
 rand = "0.7.3"
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.59"
-slog = "2.5.2"
+slog = "2.7.0"
 slog-async = "2.5.0"
 slog-term = "2.6.0"
 socks = "0.3.3"
 tokio = { version = "0.2.22", features = ["full"] }
+thiserror = "1.0.22"
 
 [build-dependencies]
 configure_me_codegen = "0.3.14"

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -92,3 +92,9 @@ doc = "Use tor for non-.onion peer connections"
 [[switch]]
 name = "default_fetch_blocks"
 doc = "Fetch blocks from peers for all users that do NOT specify fetch_blocks = false"
+
+[[switch]]
+name = "verbose"
+abbr = "v"
+doc = "Increase logging verbosity"
+count = true

--- a/src/create_state.rs
+++ b/src/create_state.rs
@@ -15,8 +15,26 @@ mod config {
 use self::config::{Config, ResultExt};
 
 pub fn create_state() -> Result<State, Error> {
+    use slog::Level;
+
     let (config, _) =
         Config::including_optional_config_files(std::iter::empty::<&str>()).unwrap_or_exit();
+
+    let log_level = match config.verbose {
+        0 => Level::Critical,
+        1 => Level::Error,
+        2 => Level::Warning,
+        3 => Level::Info,
+        4 => Level::Debug,
+        _ => Level::Trace,
+    };
+
+    let decorator = slog_term::TermDecorator::new()
+        .stderr()
+        .build();
+    let drain = slog_term::FullFormat::new(decorator).build().fuse();
+    let drain = slog_async::Async::new(drain).build().filter_level(log_level).fuse();
+    let logger = slog::Logger::root(drain, slog::o!());
 
     let auth = AuthSource::from_config(
         config.bitcoind_user,
@@ -27,19 +45,19 @@ pub fn create_state() -> Result<State, Error> {
         "http://{}:{}/",
         config.bitcoind_address, config.bitcoind_port
     )
-    .parse()?;
-    let rpc_client = RpcClient::new(auth, bitcoin_uri);
+    .parse()
+    .map_err(|error: http::uri::InvalidUri| {
+        let new_error = anyhow::anyhow!("failed to parse bitcoin URI: {}", error);
+        slog::error!(logger, "failed to parse bitcoin URI"; "error" => #error);
+        new_error
+    })?;
+    let rpc_client = RpcClient::new(auth, bitcoin_uri, &logger);
 
     let tor_only = config.tor_only;
     let tor = config.tor_proxy.map(|proxy| TorState {
         proxy,
         only: tor_only,
     });
-
-    let decorator = slog_term::TermDecorator::new().build();
-    let drain = slog_term::FullFormat::new(decorator).build().fuse();
-    let drain = slog_async::Async::new(drain).build().fuse();
-    let logger = slog::Logger::root(drain, slog::o!());
 
     Ok(State {
         bind: (config.bind_address, config.bind_port).into(),

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -40,33 +40,31 @@ pub async fn proxy_request(
                                 let state_local_err = state_local.clone();
                                 user.intercept(state_local.clone(), req)
                                     .map_ok(move |res| {
-                                        if res.is_some() {
-                                            debug!(
-                                                state_local_ok.logger,
-                                                "{} called {}: INTERCEPTED",
-                                                name_local_ok,
-                                                req.method.0
-                                            )
+                                        let action_description = if res.is_some() {
+                                            "INTERCEPTED"
                                         } else {
-                                            debug!(
-                                                state_local_ok.logger,
-                                                "{} called {}: FORWARDED",
-                                                name_local_ok,
-                                                req.method.0
-                                            )
-                                        }
+                                            "FORWARDED"
+                                        };
+
+                                        debug!(
+                                            state_local_ok.logger,
+                                            "processed request";
+                                            "user" => name_local_ok,
+                                            "method" => req.method.0.clone(),
+                                            "action" => action_description
+                                        );
                                         res
                                     })
-                                    .map_err(move |err| {
+                                    .map_err(move |error| {
                                         warn!(
                                             state_local_err.logger,
-                                            "{} called {}: ERROR {} {}",
-                                            name_local_err,
-                                            req.method.0,
-                                            err.code,
-                                            err.message
+                                            "failed request";
+                                            "user" => name_local_err,
+                                            "method" => req.method.0.clone(),
+                                            "error_code" => error.code,
+                                            "error_message" => &error.message
                                         );
-                                        err
+                                        error
                                     })
                             })
                             .await?;

--- a/src/rpc_methods.rs
+++ b/src/rpc_methods.rs
@@ -198,7 +198,7 @@ impl PeerInfo {
             let mut addr_split = self.addr.split(":");
             let host = addr_split
                 .next()
-                .expect("std::str::split() is an empty iterator which should never happen");
+                .expect("error: entered unreachable code: std::str::split() is an empty iterator which should never happen");
             let port = addr_split
                 .next()
                 .ok_or_else(|| PeerAddressError::MissingPort(self.addr.clone()))?

--- a/src/rpc_methods.rs
+++ b/src/rpc_methods.rs
@@ -1,4 +1,3 @@
-use anyhow::{anyhow, Error};
 use bitcoin::{
     consensus::Decodable,
     hash_types::BlockHash,
@@ -186,30 +185,31 @@ pub struct PeerInfo {
     /// The total bytes received aggregated by message type
     pub bytesrecv_per_msg: LinearMap<String, u64>,
 }
+
 impl PeerInfo {
-    pub fn into_address(self) -> Result<Address, Error> {
-        let services = ServiceFlags::consensus_decode(&mut std::io::Cursor::new(hex::decode(
-            &self.services,
-        )?))?;
+    pub fn into_address(self) -> Result<Address, PeerAddressError> {
+        let decoded_services = hex::decode(&self.services)
+            .map_err(|error| PeerAddressError::InvalidHex { string: self.services.clone(), error, })?;
+        let services = ServiceFlags::consensus_decode(&mut std::io::Cursor::new(decoded_services))
+            .map_err(|error| PeerAddressError::ConsensusDecode { string: self.services.clone(), error, })?;
         if let Ok(sock_addr) = self.addr.parse() {
             Ok(Address::new(&sock_addr, services))
         } else {
             let mut addr_split = self.addr.split(":");
             let host = addr_split
                 .next()
-                .ok_or_else(|| anyhow!("Invalid Peer Address: {}", self.addr))?;
+                .expect("std::str::split() is an empty iterator which should never happen");
             let port = addr_split
                 .next()
-                .ok_or_else(|| anyhow!("Invalid Peer Address: {}", self.addr))?
-                .parse()?;
-            let onion = base32::decode(
-                base32::Alphabet::RFC4648 { padding: false },
-                host.strip_suffix(".onion")
-                    .ok_or_else(|| anyhow!("Invalid Peer Address: {}", self.addr))?,
-            )
-            .ok_or_else(|| anyhow!("Invalid Peer Address: {}", self.addr))?;
+                .ok_or_else(|| PeerAddressError::MissingPort(self.addr.clone()))?
+                .parse()
+                .map_err(|error| PeerAddressError::InvalidPort { address: self.addr.clone(), error, })?;
+            let onion_key = host.strip_suffix(".onion")
+                    .ok_or_else(|| PeerAddressError::Unknown(self.addr.clone()))?;
+            let onion = base32::decode(base32::Alphabet::RFC4648 { padding: false }, onion_key)
+                .ok_or_else(|| PeerAddressError::InvalidOnionEncoding(self.addr.clone()))?;
             if onion.len() < 10 {
-                return Err(anyhow!("Invalid Peer Address: {}", self.addr));
+                return Err(PeerAddressError::InvalidOnionLength(self.addr.clone()));
             }
             let address: [u16; 8] = [
                 0xFD87,
@@ -229,6 +229,25 @@ impl PeerInfo {
         }
     }
 }
+
+#[derive(Debug, thiserror::Error)]
+pub enum PeerAddressError {
+    #[error("invalid hexadecimal encoding of {string}")]
+    InvalidHex { string: String, #[source] error: hex::FromHexError, },
+    #[error("can't consensus-decode {string}")]
+    ConsensusDecode { string: String, #[source] error: bitcoin::consensus::encode::Error, },
+    #[error("missing port in peer address {0}")]
+    MissingPort(String),
+    #[error("invalid port in address {address}")]
+    InvalidPort { address: String, #[source] error: std::num::ParseIntError, },
+    #[error("the peer address {0} is neither clearnet address nor onion address")]
+    Unknown(String),
+    #[error("base32 encoding of onion address {0} is invalid")]
+    InvalidOnionEncoding(String),
+    #[error("invalid length of onion address {0}")]
+    InvalidOnionLength(String),
+}
+
 impl RpcMethod for GetPeerInfo {
     type Params = [(); 0];
     type Response = Vec<PeerInfo>;

--- a/src/state.rs
+++ b/src/state.rs
@@ -41,7 +41,7 @@ impl State {
             tokio::task::spawn(async move {
                 match Peers::updated(&self.rpc_client).await {
                     Ok(peers) => *self.peers.write().await = Arc::new(peers),
-                    Err(e) => error!(self.logger, "{}", e.context("updating peer list")),
+                    Err(error) => error!(self.logger, "failed to update peers"; "error" => #error),
                 }
             });
         }


### PR DESCRIPTION
This improves various aspects of error handling and logging:

* Loglevel can be configured at start similarly to `electrs`
* New version of slog is used which has direct support for errors
* Formatted messages were changed to structured logging
* `anyhow::Error` replaced with custom errors at various places to make
  errors more strongly typed and allow use of error logging.
* A few minor style changes (renaming `e` to `error`, breaking up
  complex expressions...)

Cc @dr-bonez this is breaking at least `RpcClient` (added logger) but it should be trivial change. I expect to improve this stuff even more in the future. This is just some obvious improvements.