### PR TITLE
Implemented systemd socket activation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
+]
+
+[[package]]
 name = "btc-rpc-proxy"
 version = "0.2.3"
 dependencies = [
@@ -168,9 +189,16 @@ dependencies = [
  "slog-async",
  "slog-term",
  "socks",
+ "systemd_socket",
  "thiserror",
  "tokio",
 ]
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -309,6 +337,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-mac"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
+dependencies = [
+ "generic-array",
+ "subtle",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +355,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -357,6 +404,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +439,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fmt2io"
@@ -520,6 +582,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +640,16 @@ name = "hex"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+
+[[package]]
+name = "hmac"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
+dependencies = [
+ "crypto-mac",
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -682,6 +763,21 @@ name = "libc"
 version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
+
+[[package]]
+name = "libsystemd"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a64961e79726a5b05e0db592097ca895831d755484203578fe75b580847262"
+dependencies = [
+ "error-chain",
+ "hmac",
+ "libc",
+ "nix",
+ "serde",
+ "sha2",
+ "uuid",
+]
 
 [[package]]
 name = "linear-map"
@@ -799,6 +895,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
+dependencies = [
+ "bitflags",
+ "cc",
+ "cfg-if",
+ "libc",
+ "void",
+]
+
+[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -838,6 +947,12 @@ name = "once_cell"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "parse_arg"
@@ -1099,6 +1214,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
+dependencies = [
+ "block-buffer",
+ "digest",
+ "fake-simd",
+ "opaque-debug",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1170,6 +1297,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "subtle"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
+
+[[package]]
 name = "syn"
 version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1323,18 @@ dependencies = [
  "quote",
  "syn",
  "unicode-xid",
+]
+
+[[package]]
+name = "systemd_socket"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9142be19400d094bab8a1b93f5059aa2147f7ab5760546ce6632a82b69085a4b"
+dependencies = [
+ "lazy_static",
+ "libsystemd",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -1349,6 +1494,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
+name = "typenum"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1359,6 +1510,21 @@ name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
+
+[[package]]
+name = "uuid"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
 
 [[package]]
 name = "void"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,9 +20,10 @@ path = "src/main.rs"
 spec = "config_spec.toml"
 
 [features]
-default = ["debug_logs"]
+default = ["debug_logs", "systemd"]
 old_rust = []
 debug_logs = ["slog/max_level_debug"]
+systemd = ["systemd_socket/enable_systemd"]
 
 [dependencies]
 anyhow = "1.0.34"
@@ -49,6 +50,7 @@ slog-term = "2.6.0"
 socks = "0.3.3"
 tokio = { version = "0.2.22", features = ["full"] }
 thiserror = "1.0.22"
+systemd_socket = { version = "0.1.1", default-features = false, features = ["tokio_0_2"] }
 
 [build-dependencies]
 configure_me_codegen = "0.3.14"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ An example configuration file is provided in this repository, hopefuly it's unde
 
 A man page is also generated during build and `--help` option is provided.
 
+### Systemd integration
+
+Using socket activation enables you to delay the start of `btc-rpc-proxy` until it's actually needed or start it in parallel with its clients leading to faster boot times.
+
+Systemd socket activation is configured using `bind_systemd_socket_name` option.
+Setting it to a valid socket name will cause `btc-rpc-proxy` to use systemd socket activation using the socket with the specified socket name.
+
+This feature is only available for Linux and only if the `systemd` feature is enabled. (Enabled by default.)
+Disabling it can decrease compile time and binary size but please keep it enabled if you intend to distribute the binary so that the users can benefit from it.
+Especially in case of packaged software.
+
 ## Limitations
 
 * It uses `serde_json`, which allocates during deserialization (`Value`). Expect a bit lower performance than without proxy.

--- a/config_spec.toml
+++ b/config_spec.toml
@@ -27,7 +27,7 @@ doc = "The file in which bitcoind stores authentication cookie. Can be used inst
 [[param]]
 name = "bind_address"
 type = "::std::net::IpAddr"
-default = "[127, 0, 0, 1].into()"
+optional = true
 doc = "The address used for listening."
 #debconf_priority = "low"
 #debconf_default = "127.0.0.1"
@@ -35,10 +35,16 @@ doc = "The address used for listening."
 [[param]]
 name = "bind_port"
 type = "u16"
-default = "8331"
+optional = true
 doc = "The port used for listening."
 #debconf_priority = "low"
 #debconf_default = "8331"
+
+[[param]]
+name = "bind_systemd_socket_name"
+type = "String"
+optional = true
+doc = "The systemd socket name used for listening - conflicts with bind_address and bind_port"
 
 [[param]]
 name = "bitcoind_address"

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,6 @@ mod create_state;
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-    let state = create_state::create_state()?.arc();
-    btc_rpc_proxy::main(state).await
+    let (state, bind_addr) = create_state::create_state()?;
+    btc_rpc_proxy::main(state.arc(), bind_addr).await
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -18,7 +18,6 @@ pub struct TorState {
 
 #[derive(Debug)]
 pub struct State {
-    pub bind: SocketAddr,
     pub rpc_client: RpcClient,
     pub tor: Option<TorState>,
     pub users: Users,


### PR DESCRIPTION
This adds support for systemd socket activation which can improve boot
times while avoiding spurious "connection refused" errors in clients.
This uses the new `systemd_socket` crate (created by me).

It is a breaking change in lib API because the listener must be passed
separately since it's not reusable. The configuration is
backwards-compatible.

**Not tested yet**

@dr-bonez 