### PR TITLE
Removed rand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,6 @@ dependencies = [
  "itertools",
  "lazy_static",
  "linear-map",
- "rand",
  "serde",
  "serde_json",
  "slog",
@@ -848,12 +847,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
-
-[[package]]
 name = "proc-macro-hack"
 version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,46 +874,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ hyper = "0.13.9"
 itertools = "0.9.0"
 lazy_static = "1.4.0"
 linear-map = { version = "1.2.0", features = ["serde_impl"] }
-rand = "0.8.0"
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = "1.0.59"
 slog = "2.7.0"

--- a/src/fetch_blocks.rs
+++ b/src/fetch_blocks.rs
@@ -44,7 +44,8 @@ lazy_static::lazy_static! {
                     .as_secs() as i64,
                 addr,
                 Address::new(&([127, 0, 0, 1], 8332).into(), ServiceFlags::NONE),
-                rand::random(),
+                // This is OK because RPC proxy doesn't listen on P2P
+                0,
                 format!("BTC RPC Proxy v{}", env!("CARGO_PKG_VERSION")),
                 0,
             )),


### PR DESCRIPTION
The `nonce` in `VersionMessage` is used for detecting connection to
self. This is not needed because we don't listen on P2P, so by
definition we can't connect to self.

See https://github.com/rust-bitcoin/rust-bitcoin/issues/575 for more
discussion.

Cc @dr-bonez I believe we should test this a bit before merging.